### PR TITLE
Attribute accessibility improvements, and icons

### DIFF
--- a/custom_components/kubernetes/const.py
+++ b/custom_components/kubernetes/const.py
@@ -29,3 +29,12 @@ PANEL_URL = f"{URL_BASE}/panel.js"
 
 FRONTEND_PANEL_TITLE = "Kubernetes"
 FRONTEND_PANEL_ICON = "mdi:kubernetes"
+
+ICON_NODE_OK = "mdi:server-network"
+ICON_NODE_NOTOK = "mdi:server-network-off"
+ICON_DAEMONSET_OK = "mdi:checkbox-multiple-marked"
+ICON_DAEMONSET_NOTOK = "mdi:close-box-multiple"
+ICON_DEPLOYMENT_OK = "mdi:checkbox-multiple-marked"
+ICON_DEPLOYMENT_NOTOK = "mdi:close-box-multiple"
+ICON_POD_OK = "mdi:archive-outline"
+ICON_POD_NOTOK = "mdi:archive-off-outline"

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -65,5 +65,4 @@ class KubernetesEntity(Entity):
     @property
     def extra_state_attributes(self) -> dict:
         dict = { "raw" : obj_to_dict(self.getData()) }
-        dict["kind"] = self.getData().kind
         return 

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -64,8 +64,8 @@ class KubernetesEntity(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        data = obj_to_dict(self.getData())
-        attr = { "raw" : data }
+        data = self.getData()
+        attr = { "raw" : obj_to_dict(data) }
         attr["device_class"] = data.kind
         return attr
    

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -64,6 +64,4 @@ class KubernetesEntity(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        dict = {}
-        dict["raw"] = obj_to_dict(self.getData())
-        return dict
+        return { "raw" : obj_to_dict(self.getData()) }

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -64,4 +64,6 @@ class KubernetesEntity(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        return { "raw": obj_to_dict(self.getData()) }
+        dict = {}
+        dict["raw"] = obj_to_dict(self.getData())
+        return dict

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -64,4 +64,4 @@ class KubernetesEntity(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        return obj_to_dict(self.getData())
+        return { "raw": obj_to_dict(self.getData()) }

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -64,5 +64,4 @@ class KubernetesEntity(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        dict = { "raw" : obj_to_dict(self.getData()) }
-        return 
+        return { "raw" : obj_to_dict(self.getData()) }

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -64,4 +64,8 @@ class KubernetesEntity(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        return { "raw" : obj_to_dict(self.getData()) }
+        data = obj_to_dict(self.getData())
+        attr = { "raw" : data }
+        attr["device_class"] = data.kind
+        return attr
+   

--- a/custom_components/kubernetes/kubernetes_entity.py
+++ b/custom_components/kubernetes/kubernetes_entity.py
@@ -64,4 +64,6 @@ class KubernetesEntity(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        return { "raw" : obj_to_dict(self.getData()) }
+        dict = { "raw" : obj_to_dict(self.getData()) }
+        dict["kind"] = self.getData().kind
+        return 

--- a/custom_components/kubernetes/sensors/daemon_set_sensor.py
+++ b/custom_components/kubernetes/sensors/daemon_set_sensor.py
@@ -66,12 +66,15 @@ class DaemonSetSensor(KubernetesEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        d = super().extra_state_attributes
+        attr = super().extra_state_attributes
+        data = self.getData()
 
         # Add helpers for DaemonSet.
-        d["current_pods_scheduled"] = d["status"]["current_number_scheduled"]
-        d["desired_pods_scheduled"] = d["status"]["desired_number_scheduled"]
-        d["pods_available"] = d["status"]["number_available"]
-        d["pods_unavailable"] = d["status"]["number_unavailable"]
+        attr["namespace"] = data.metadata.namespace
 
-        return d
+        attr["current_pods_scheduled"] = data.status.current_number_scheduled
+        attr["desired_pods_scheduled"] = data.status.desired_number_scheduled
+        attr["pods_available"] = data.status.number_available
+        attr["pods_unavailable"] = data.status.number_unavailable
+
+        return attr

--- a/custom_components/kubernetes/sensors/daemon_set_sensor.py
+++ b/custom_components/kubernetes/sensors/daemon_set_sensor.py
@@ -13,6 +13,8 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from ..kubernetes_entity import KubernetesEntity
 from ..const import (
     DOMAIN,
+    ICON_DAEMONSET_NOTOK,
+    ICON_DAEMONSET_OK,
     SERVICE_SET_IMAGE_DAEMONSET,
     PARAM_CONTAINER,
     PARAM_IMAGE,
@@ -64,6 +66,13 @@ class DaemonSetSensor(KubernetesEntity, SensorEntity):
             image,
         )
 
+    def is_ok(self) -> bool:
+        status = self.getData().status
+        cps = status.current_number_scheduled
+        pa = status.number_available
+
+        return (pa == cps)
+
     @property
     def extra_state_attributes(self) -> dict:
         attr = super().extra_state_attributes
@@ -77,4 +86,14 @@ class DaemonSetSensor(KubernetesEntity, SensorEntity):
         attr["pods_available"] = data.status.number_available
         attr["pods_unavailable"] = data.status.number_unavailable
 
+        attr["ok"] = self.is_ok()
+
         return attr
+
+    @property
+    def icon(self):
+        if self.is_ok:
+            return ICON_DAEMONSET_OK
+        else:
+            return ICON_DAEMONSET_NOTOK
+

--- a/custom_components/kubernetes/sensors/daemon_set_sensor.py
+++ b/custom_components/kubernetes/sensors/daemon_set_sensor.py
@@ -53,7 +53,7 @@ class DaemonSetSensor(KubernetesEntity, SensorEntity):
 
     @property
     def state(self) -> str:
-        return self.getData().status.number_ready
+        return self.is_ok()
 
     @staticmethod
     def kind() -> str:

--- a/custom_components/kubernetes/sensors/daemon_set_sensor.py
+++ b/custom_components/kubernetes/sensors/daemon_set_sensor.py
@@ -63,3 +63,15 @@ class DaemonSetSensor(KubernetesEntity, SensorEntity):
             container,
             image,
         )
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        d = super().extra_state_attributes
+
+        # Add helpers for DaemonSet.
+        d["current_pods_scheduled"] = d["status"]["current_number_scheduled"]
+        d["desired_pods_scheduled"] = d["status"]["desired_number_scheduled"]
+        d["pods_available"] = d["status"]["number_available"]
+        d["pods_unavailable"] = d["status"]["number_unavailable"]
+
+        return d

--- a/custom_components/kubernetes/sensors/deployment_sensor.py
+++ b/custom_components/kubernetes/sensors/deployment_sensor.py
@@ -63,3 +63,17 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
             container,
             image,
         )
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        d = super().extra_state_attributes
+
+        # Add helpers for deployment.
+        d["conditions"] = d["status"]["conditions"]
+
+        d["paused"] = d["spec"]["paused"]
+        d["specified_replicas"] = d["spec"]["replicas"]
+        d["available_replicas"] = d["status"]["available_replicas"]
+        d["unavailable_replicas"] = d["status"]["unavailable_replicas"]
+
+        return d

--- a/custom_components/kubernetes/sensors/deployment_sensor.py
+++ b/custom_components/kubernetes/sensors/deployment_sensor.py
@@ -53,7 +53,7 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
 
     @property
     def state(self) -> str:
-        return self.getData().status.ready_replicas
+        return self.is_ok()
 
     @staticmethod
     def kind() -> str:

--- a/custom_components/kubernetes/sensors/deployment_sensor.py
+++ b/custom_components/kubernetes/sensors/deployment_sensor.py
@@ -66,14 +66,16 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        d = super().extra_state_attributes
+        attr = super().extra_state_attributes
+        data = self.getData()
 
         # Add helpers for deployment.
-        d["conditions"] = d["status"]["conditions"]
+        attr["conditions"] = attr["status"]["conditions"]
+        attr["namespace"] = data.metadata.namespace
 
-        d["paused"] = d["spec"]["paused"]
-        d["specified_replicas"] = d["spec"]["replicas"]
-        d["available_replicas"] = d["status"]["available_replicas"]
-        d["unavailable_replicas"] = d["status"]["unavailable_replicas"]
+        attr["paused"] = data.spec.paused
+        attr["specified_replicas"] = data.spec.replicas
+        attr["available_replicas"] = data.status.available_replicas
+        attr["unavailable_replicas"] = data.status.unavailable_replicas
 
-        return d
+        return attr

--- a/custom_components/kubernetes/sensors/deployment_sensor.py
+++ b/custom_components/kubernetes/sensors/deployment_sensor.py
@@ -70,7 +70,7 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
         data = self.getData()
 
         # Add helpers for deployment.
-        attr["conditions"] = data.status.conditions
+        attr["conditions"] = super().obj_to_dict(data.status.conditions)
         attr["namespace"] = data.metadata.namespace
 
         attr["paused"] = data.spec.paused

--- a/custom_components/kubernetes/sensors/deployment_sensor.py
+++ b/custom_components/kubernetes/sensors/deployment_sensor.py
@@ -12,6 +12,8 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 
 from ..const import (
     DOMAIN,
+    ICON_DEPLOYMENT_NOTOK,
+    ICON_DEPLOYMENT_OK,
     SERVICE_SET_IMAGE_DEPLOYMENT,
     PARAM_CONTAINER,
     PARAM_IMAGE,
@@ -64,6 +66,13 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
             image,
         )
 
+    def is_ok(self) -> bool:
+        data = self.getData()
+        sr = data.spec.replicas
+        ar = data.status.available_replicas
+
+        return (ar == sr)
+
     @property
     def extra_state_attributes(self) -> dict:
         attr = super().extra_state_attributes
@@ -78,4 +87,13 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
         attr["available_replicas"] = data.status.available_replicas
         attr["unavailable_replicas"] = data.status.unavailable_replicas
 
+        attr["ok"] = self.is_ok()
+
         return attr
+
+    @property
+    def icon(self):
+        if self.is_ok:
+            return ICON_DEPLOYMENT_OK
+        else:
+            return ICON_DEPLOYMENT_NOTOK

--- a/custom_components/kubernetes/sensors/deployment_sensor.py
+++ b/custom_components/kubernetes/sensors/deployment_sensor.py
@@ -70,7 +70,7 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
         data = self.getData()
 
         # Add helpers for deployment.
-        attr["conditions"] = attr["status"]["conditions"]
+        attr["conditions"] = data.status.conditions
         attr["namespace"] = data.metadata.namespace
 
         attr["paused"] = data.spec.paused

--- a/custom_components/kubernetes/sensors/deployment_sensor.py
+++ b/custom_components/kubernetes/sensors/deployment_sensor.py
@@ -17,7 +17,7 @@ from ..const import (
     PARAM_IMAGE,
     KUBERNETES_KIND_DEPLOYMENT,
 )
-from ..kubernetes_entity import KubernetesEntity
+from ..kubernetes_entity import KubernetesEntity, obj_to_dict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class DeploymentSensor(KubernetesEntity, SensorEntity):
         data = self.getData()
 
         # Add helpers for deployment.
-        attr["conditions"] = super().obj_to_dict(data.status.conditions)
+        attr["conditions"] = obj_to_dict(data.status.conditions)
         attr["namespace"] = data.metadata.namespace
 
         attr["paused"] = data.spec.paused

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -73,13 +73,13 @@ class NodeSensor(KubernetesEntity, SensorEntity):
 
       # Add helpers for node.
       # Addresses
-      attr["addresses"] = data.status.addresses
+      attr["addresses"] = super().obj_to_dict(data.status.addresses)
 
       # Conditions
-      attr["conditions"] = data.status.conditions
+      attr["conditions"] = super().obj_to_dict(data.status.conditions)
 
       # Labels
-      attr["labels"] = data.metadata.labels
+      attr["labels"] = super().obj_to_dict(data.metadata.labels)
 
       # Node info
       ni = data.status.node_info

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -65,3 +65,28 @@ class NodeSensor(KubernetesEntity, SensorEntity):
 
     async def set_unschedulable(self, unschedulable: bool) -> None:
         await self.hub.set_unschedulable(self.getData().metadata.name, unschedulable)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+      d = super().extra_state_attributes()
+
+      # Add helpers for node.
+      # Addresses
+      d["addresses"] = d["status"]["addresses"]
+
+      # Conditions
+      d["conditions"] = d["status"]["conditions"]
+
+      # Node info
+      d["architecture"] = d["status"]["node_info"]["architecture"]
+      d["boot_id"] = d["status"]["conditions"]["status"]["node_info"]["boot_id"]
+      d["container_runtime_version"] = d["status"]["conditions"]["status"]["node_info"]["container_runtime_version"]
+      d["kernel_version"] = d["status"]["conditions"]["status"]["node_info"]["kernel_version"]
+      d["kube_proxy_version"] = d["status"]["conditions"]["status"]["node_info"]["kube_proxy_version"]
+      d["kubelet_version"] = d["status"]["conditions"]["status"]["node_info"]["kubelet_version"]
+      d["machine_id"] = d["status"]["conditions"]["status"]["node_info"]["machine_id"]
+      d["operating_system"] = d["status"]["conditions"]["status"]["node_info"]["operating_system"]
+      d["os_image"] = d["status"]["conditions"]["status"]["node_info"]["os_image"]
+      d["system_uuid"] = d["status"]["conditions"]["status"]["node_info"]["system_uuid"]
+
+      return d

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -12,6 +12,8 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 
 from ..const import (
     DOMAIN,
+    ICON_NODE_NOTOK,
+    ICON_NODE_OK,
     SERVICE_SET_UNSCHEDULABLE,
     PARAM_UNSCHEDULABLE,
     STATE_READY,
@@ -66,6 +68,9 @@ class NodeSensor(KubernetesEntity, SensorEntity):
     async def set_unschedulable(self, unschedulable: bool) -> None:
         await self.hub.set_unschedulable(self.getData().metadata.name, unschedulable)
 
+    def is_ok(self) -> bool:
+        return (self.state == "KubeletReady")
+
     @property
     def extra_state_attributes(self) -> dict:
       attr = super().extra_state_attributes
@@ -97,4 +102,13 @@ class NodeSensor(KubernetesEntity, SensorEntity):
 
       attr["pod_cidr"] = data.spec.pod_cidr
 
+      attr["ok"] = self.is_ok()
+
       return attr
+
+    @property
+    def icon(self):
+        if self.is_ok:
+            return ICON_NODE_OK
+        else:
+            return ICON_NODE_NOTOK

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -19,7 +19,7 @@ from ..const import (
     KUBERNETES_KIND_NODE,
 )
 
-from ..kubernetes_entity import KubernetesEntity
+from ..kubernetes_entity import KubernetesEntity, obj_to_dict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,13 +73,13 @@ class NodeSensor(KubernetesEntity, SensorEntity):
 
       # Add helpers for node.
       # Addresses
-      attr["addresses"] = super().obj_to_dict(data.status.addresses)
+      attr["addresses"] = obj_to_dict(data.status.addresses)
 
       # Conditions
-      attr["conditions"] = super().obj_to_dict(data.status.conditions)
+      attr["conditions"] = obj_to_dict(data.status.conditions)
 
       # Labels
-      attr["labels"] = super().obj_to_dict(data.metadata.labels)
+      attr["labels"] = obj_to_dict(data.metadata.labels)
 
       # Node info
       ni = data.status.node_info

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -68,27 +68,32 @@ class NodeSensor(KubernetesEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict:
-      d = super().extra_state_attributes
+      attr = super().extra_state_attributes
+      data = self.getData()
 
       # Add helpers for node.
       # Addresses
-      d["addresses"] = d["status"]["addresses"]
+      attr["addresses"] = data.status.addresses
 
       # Conditions
-      d["conditions"] = d["status"]["conditions"]
+      attr["conditions"] = data.status.conditions
+
+      # Labels
+      attr["labels"] = data.metadata.labels
 
       # Node info
-      d["architecture"] = d["status"]["node_info"]["architecture"]
-      d["boot_id"] = d["status"]["node_info"]["boot_id"]
-      d["container_runtime_version"] = d["status"]["node_info"]["container_runtime_version"]
-      d["kernel_version"] = d["status"]["node_info"]["kernel_version"]
-      d["kube_proxy_version"] = d["status"]["node_info"]["kube_proxy_version"]
-      d["kubelet_version"] = d["status"]["node_info"]["kubelet_version"]
-      d["labels"] = d["metadata"]["labels"]
-      d["machine_id"] = d["status"]["node_info"]["machine_id"]
-      d["operating_system"] = d["status"]["node_info"]["operating_system"]
-      d["os_image"] = d["status"]["node_info"]["os_image"]
-      d["pod_cidr"] = d["spec"]["pod_cidr"]
-      d["system_uuid"] = d["status"]["node_info"]["system_uuid"]
+      ni = data.status.node_info
 
-      return d
+      attr["architecture"] = ni.architecture
+      attr["boot_id"] = ni.boot_id
+      attr["container_runtime_version"] = ni.container_runtime_version
+      attr["kernel_version"] = ni.kernel_version
+      attr["kube_proxy_version"] = ni.kube_proxy_version
+      attr["kubelet_version"] = ni.kubelet_version
+      attr["machine_id"] = ni.machine_id
+      attr["operating_system"] = ni.operating_system
+      attr["os_image"] = ni.os_image
+      attr["pod_cidr"] = ni.pod_cidr
+      attr["system_uuid"] = ni.system_uuid
+
+      return attr

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -93,7 +93,8 @@ class NodeSensor(KubernetesEntity, SensorEntity):
       attr["machine_id"] = ni.machine_id
       attr["operating_system"] = ni.operating_system
       attr["os_image"] = ni.os_image
-      attr["pod_cidr"] = ni.pod_cidr
       attr["system_uuid"] = ni.system_uuid
+
+      attr["pod_cidr"] = data.spec.pod_cidr
 
       return attr

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -65,3 +65,28 @@ class NodeSensor(KubernetesEntity, SensorEntity):
 
     async def set_unschedulable(self, unschedulable: bool) -> None:
         await self.hub.set_unschedulable(self.getData().metadata.name, unschedulable)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+      d = super().extra_state_attributes
+
+      # Add helpers for node.
+      # Addresses
+      d["addresses"] = d["status"]["addresses"]
+
+      # Conditions
+      d["conditions"] = d["status"]["conditions"]
+
+      # Node info
+      d["architecture"] = d["status"]["node_info"]["architecture"]
+      d["boot_id"] = d["status"]["node_info"]["boot_id"]
+      d["container_runtime_version"] = d["status"]["node_info"]["container_runtime_version"]
+      d["kernel_version"] = d["status"]["node_info"]["kernel_version"]
+      d["kube_proxy_version"] = d["status"]["node_info"]["kube_proxy_version"]
+      d["kubelet_version"] = d["status"]["node_info"]["kubelet_version"]
+      d["machine_id"] = d["status"]["node_info"]["machine_id"]
+      d["operating_system"] = d["status"]["node_info"]["operating_system"]
+      d["os_image"] = d["status"]["node_info"]["os_image"]
+      d["system_uuid"] = d["status"]["node_info"]["system_uuid"]
+
+      return d

--- a/custom_components/kubernetes/sensors/node_sensor.py
+++ b/custom_components/kubernetes/sensors/node_sensor.py
@@ -84,9 +84,11 @@ class NodeSensor(KubernetesEntity, SensorEntity):
       d["kernel_version"] = d["status"]["node_info"]["kernel_version"]
       d["kube_proxy_version"] = d["status"]["node_info"]["kube_proxy_version"]
       d["kubelet_version"] = d["status"]["node_info"]["kubelet_version"]
+      d["labels"] = d["metadata"]["labels"]
       d["machine_id"] = d["status"]["node_info"]["machine_id"]
       d["operating_system"] = d["status"]["node_info"]["operating_system"]
       d["os_image"] = d["status"]["node_info"]["os_image"]
+      d["pod_cidr"] = d["spec"]["pod_cidr"]
       d["system_uuid"] = d["status"]["node_info"]["system_uuid"]
 
       return d

--- a/custom_components/kubernetes/sensors/pod_sensor.py
+++ b/custom_components/kubernetes/sensors/pod_sensor.py
@@ -42,3 +42,17 @@ class PodSensor(KubernetesEntity, SensorEntity):
     @staticmethod
     def kind() -> str:
         return KUBERNETES_KIND_POD
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        d = super().extra_state_attributes
+
+        # Add helpers for pod.
+        # Conditions
+        d["conditions"] = d["status"]["conditions"]
+
+        d["node"] = d["spec"]["node_name"]
+        d["phase"] = d["status"]["phase"]
+        d["pod_ip"] = d["status"]["pod_ip"]
+
+        return d

--- a/custom_components/kubernetes/sensors/pod_sensor.py
+++ b/custom_components/kubernetes/sensors/pod_sensor.py
@@ -52,6 +52,9 @@ class PodSensor(KubernetesEntity, SensorEntity):
         # Conditions
         attr["conditions"] = data.status.conditions
 
+        # Namespace
+        attr["namespace"] = data.metadata.namespace
+
         attr["node"] = data.spec.node_name
         attr["phase"] = data.status.phase
         attr["pod_ip"] = data.status.pod_ip

--- a/custom_components/kubernetes/sensors/pod_sensor.py
+++ b/custom_components/kubernetes/sensors/pod_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import config_validation as cv, entity_platform
 
 from ..const import DOMAIN, KUBERNETES_KIND_POD
-from ..kubernetes_entity import KubernetesEntity
+from ..kubernetes_entity import KubernetesEntity, obj_to_dict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class PodSensor(KubernetesEntity, SensorEntity):
 
         # Add helpers for pod.
         # Conditions
-        attr["conditions"] = super().obj_to_dict(data.status.conditions)
+        attr["conditions"] = obj_to_dict(data.status.conditions)
 
         # Namespace
         attr["namespace"] = data.metadata.namespace

--- a/custom_components/kubernetes/sensors/pod_sensor.py
+++ b/custom_components/kubernetes/sensors/pod_sensor.py
@@ -10,7 +10,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import config_validation as cv, entity_platform
 
-from ..const import DOMAIN, KUBERNETES_KIND_POD
+from ..const import (
+    DOMAIN,
+    ICON_POD_NOTOK,
+    ICON_POD_OK,
+    KUBERNETES_KIND_POD
+)
 from ..kubernetes_entity import KubernetesEntity, obj_to_dict
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +48,9 @@ class PodSensor(KubernetesEntity, SensorEntity):
     def kind() -> str:
         return KUBERNETES_KIND_POD
 
+    def is_ok(self) -> bool:
+        return (self.state() == "Running")
+
     @property
     def extra_state_attributes(self) -> dict:
         attr = super().extra_state_attributes
@@ -59,4 +67,13 @@ class PodSensor(KubernetesEntity, SensorEntity):
         attr["phase"] = data.status.phase
         attr["pod_ip"] = data.status.pod_ip
 
+        attr["ok"] = self.is_ok()
+
         return attr
+
+    @property
+    def icon(self):
+        if self.is_ok:
+            return ICON_POD_OK
+        else:
+            return ICON_POD_NOTOK

--- a/custom_components/kubernetes/sensors/pod_sensor.py
+++ b/custom_components/kubernetes/sensors/pod_sensor.py
@@ -50,7 +50,7 @@ class PodSensor(KubernetesEntity, SensorEntity):
 
         # Add helpers for pod.
         # Conditions
-        attr["conditions"] = data.status.conditions
+        attr["conditions"] = super().obj_to_dict(data.status.conditions)
 
         # Namespace
         attr["namespace"] = data.metadata.namespace

--- a/custom_components/kubernetes/sensors/pod_sensor.py
+++ b/custom_components/kubernetes/sensors/pod_sensor.py
@@ -49,7 +49,7 @@ class PodSensor(KubernetesEntity, SensorEntity):
         return KUBERNETES_KIND_POD
 
     def is_ok(self) -> bool:
-        return (self.state() == "Running")
+        return (self.state == "Running")
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/kubernetes/sensors/pod_sensor.py
+++ b/custom_components/kubernetes/sensors/pod_sensor.py
@@ -45,14 +45,15 @@ class PodSensor(KubernetesEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        d = super().extra_state_attributes
+        attr = super().extra_state_attributes
+        data = self.getData()
 
         # Add helpers for pod.
         # Conditions
-        d["conditions"] = d["status"]["conditions"]
+        attr["conditions"] = data.status.conditions
 
-        d["node"] = d["spec"]["node_name"]
-        d["phase"] = d["status"]["phase"]
-        d["pod_ip"] = d["status"]["pod_ip"]
+        attr["node"] = data.spec.node_name
+        attr["phase"] = data.status.phase
+        attr["pod_ip"] = data.status.pod_ip
 
-        return d
+        return attr


### PR DESCRIPTION
I made some modifications to this integration for my own use, so thought I'd share them back in case you think they're worth including:

- For each type of entity, I broke some (the ones I most needed, in this case, for tracking status) of the k8s properties out into top-level attributes to make them easier to access with, for instance, the auto-entities card, and automations without having to repeat templates each time.
- I moved the complete k8s object dump under the "raw" attribute, rather than leaving it to several top-level attributes; this to ensure the integration controls the attribute namespace and future k8s changes don't step on anything. This is a breaking change, but I think a worthwhile one?
- I added an "ok" attribute checking the status of each type of entity: that nodes are KubeletReady, that deployments and daemonsets have the correct number of pods available, and that pods are in the running state; I then also use this to provide provide icons which change with ok/not-ok status for each type of entity.

Small stuff, but hopefully worthwhile!
